### PR TITLE
Fix AAR javadoc/sources + potential leak with listeners.

### DIFF
--- a/adapters/build.gradle
+++ b/adapters/build.gradle
@@ -15,11 +15,10 @@ android {
         project.archivesBaseName = "android-adapters"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
-    buildTypes {
-        release {
-            minifyEnabled false
-        }
-    }
+}
+
+configurations {
+    javadoc
 }
 
 dependencies {
@@ -28,16 +27,16 @@ dependencies {
     androidTestCompile 'com.android.support.test:runner:0.4.1'
     androidTestCompile 'com.android.support.test:rules:0.4.1'
     androidTestCompile 'junit:junit:4.12'
-}
 
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
+    // TODO Hacking it for now. Try to make this work only from the javadoc task
+    javadoc "io.realm:realm-android-library:${rootProject.realmVersion}"
+    javadoc "io.realm:realm-annotations:${rootProject.realmVersion}"
 }
 
 task javadoc(type: Javadoc) {
-    source android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    source = android.sourceSets.main.java.srcDirs
+    classpath += configurations.javadoc
+
     options {
         title = "Realm Android Adapters ${project.version}"
         memberLevel = JavadocMemberLevel.PUBLIC
@@ -48,6 +47,11 @@ task javadoc(type: Javadoc) {
     }
     exclude '**/BuildConfig.java'
     exclude '**/R.java'
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -125,4 +129,15 @@ artifactory {
             publishIvy = false
         }
     }
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+// See https://github.com/chrisbanes/gradle-mvn-push/pull/13
+afterEvaluate {
+    javadoc.classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    javadoc.classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
 }

--- a/adapters/src/main/java/io/realm/RealmBaseAdapter.java
+++ b/adapters/src/main/java/io/realm/RealmBaseAdapter.java
@@ -59,7 +59,7 @@ public abstract class RealmBaseAdapter<T extends RealmModel> extends BaseAdapter
     private void addListener(OrderedRealmCollection<T> data) {
         if (data instanceof RealmResults) {
             RealmResults realmResults = (RealmResults) data;
-            realmResults.addChangeListener(listener);
+            realmResults.realm.handlerController.addChangeListenerAsWeakReference(listener);
         } else if (data instanceof RealmList) {
             RealmList realmList = (RealmList) data;
             realmList.realm.handlerController.addChangeListenerAsWeakReference(listener);
@@ -71,7 +71,7 @@ public abstract class RealmBaseAdapter<T extends RealmModel> extends BaseAdapter
     private void removeListener(OrderedRealmCollection<T> data) {
         if (data instanceof RealmResults) {
             RealmResults realmResults = (RealmResults) data;
-            realmResults.removeChangeListener(listener);
+            realmResults.realm.handlerController.removeWeakChangeListener(listener);
         } else if (data instanceof RealmList) {
             RealmList realmList = (RealmList) data;
             realmList.realm.handlerController.removeWeakChangeListener(listener);

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,11 @@
 apply plugin: 'ch.netzwerg.release'
 project.ext.sdkVersion = 23
 project.ext.buildTools = '23.0.0'
+project.ext.realmVersion = '0.90.0'
 
 buildscript {
     repositories {
         jcenter()
-        maven {
-            url 'http://oss.jfrog.org/artifactory/oss-snapshot-local'
-        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.0'                    // Android Build tools
@@ -26,9 +24,6 @@ allprojects {
     version = file("${rootDir}/version.txt").text.trim();
     repositories {
         jcenter()
-        maven {
-            url 'http://oss.jfrog.org/artifactory/oss-snapshot-local'
-        }
     }
 }
 


### PR DESCRIPTION
Javadoc + sources was not released when uploading to BinTray which meant we here not allowed to promote it to JCenter (doh).

This PR fixes that in a horrible way, but apparently getting the Javadoc task playing nice with external dependencies is not really supported well. So this is a "fix-fast" approach.

Also, a un-wanted refactor had snuck in when migrating from Realm Java. This have been removed as well.

@realm/java