### PR TITLE
fixed manifest merge issue

### DIFF
--- a/adapters/src/main/AndroidManifest.xml
+++ b/adapters/src/main/AndroidManifest.xml
@@ -1,9 +1,3 @@
-<manifest package="io.realm.android"
-          xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <application
-        android:allowBackup="true"
-        android:supportsRtl="true">
-    </application>
+<manifest package="io.realm.android">
 
 </manifest>


### PR DESCRIPTION
The application element in the manifest is not needed and forces users of this library to utilize `tools:replace="android:allowBackup"` when switching to `android:allowBackup="false"` in their manifest. allowBackup is true by default in any case. Focusing RTL with `supportsRtl="true"` might be less likely to cause an issue but is just unnecessary.