### PR TITLE
Updated changelog + renamed RealmRecyclerBaseAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.10
+
+### Enhancements
+
+* `RealmRecyclerViewAdapter`, a new adapter base class for `RecyclerView`s.
+
+### Bug fixes
+
+* Removed `allowBackup` and `supportsRtl` from the Android manifest file.
+
+### Credits
+
+* @thesurix for adding the `RealmRecyclerViewAdapter`.
+* Mitchell Tilbrook (@marukami) for cleaning up the `AndroidManifest.xml`.`
+
+
 ## 1.0.1
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Credits
 
-* @thesurix for adding the `RealmRecyclerViewAdapter`.
+* Paweł Surówka (@thesurix) for adding the `RealmRecyclerViewAdapter`.
 * Mitchell Tilbrook (@marukami) for cleaning up the `AndroidManifest.xml`.`
 
 

--- a/adapters/src/androidTest/java/io/realm/RealmRecyclerAdapterTests.java
+++ b/adapters/src/androidTest/java/io/realm/RealmRecyclerAdapterTests.java
@@ -29,7 +29,7 @@ import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.widget.FrameLayout;
 
-import io.realm.adapter.RealmRecyclerAdapter;
+import io.realm.adapter.RecyclerViewTestAdapter;
 import io.realm.entity.AllJavaTypes;
 import io.realm.entity.UnsupportedCollection;
 
@@ -75,7 +75,7 @@ public class RealmRecyclerAdapterTests {
     public void constructor_testRecyclerAdapterParameterExceptions() {
         RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).findAll();
         try {
-            new RealmRecyclerAdapter(null, resultList, AUTOMATIC_UPDATE);
+            new RecyclerViewTestAdapter(null, resultList, AUTOMATIC_UPDATE);
             fail("Should throw exception if context is null");
         } catch (IllegalArgumentException ignore) {
         }
@@ -85,7 +85,7 @@ public class RealmRecyclerAdapterTests {
     @UiThreadTest
     public void clear() {
         RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).findAll();
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, resultList, AUTOMATIC_UPDATE);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, resultList, AUTOMATIC_UPDATE);
         realm.beginTransaction();
         resultList.deleteAllFromRealm();
         realm.commitTransaction();
@@ -99,7 +99,7 @@ public class RealmRecyclerAdapterTests {
     public void updateData_realmResultInAdapter() {
         RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).findAll();
         resultList.sort(AllJavaTypes.FIELD_STRING);
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, resultList, false);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, resultList, false);
         assertEquals(resultList.first().getFieldString(), realmAdapter.getData().first().getFieldString());
         assertEquals(resultList.size(), realmAdapter.getData().size());
 
@@ -119,7 +119,7 @@ public class RealmRecyclerAdapterTests {
     @UiThreadTest
     public void updateData_realmUnsupportedCollectionInAdapter() {
         try {
-            RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, null, AUTOMATIC_UPDATE);
+            RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, null, AUTOMATIC_UPDATE);
             realmAdapter.updateData(new UnsupportedCollection<AllJavaTypes>());
             fail("Should throw exception if there is unsupported collection");
         } catch (IllegalArgumentException ignore) {
@@ -130,7 +130,7 @@ public class RealmRecyclerAdapterTests {
     @UiThreadTest
     public void getItemCount_emptyRealmResult() {
         RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).equalTo(AllJavaTypes.FIELD_STRING, "Not there").findAll();
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, resultList, AUTOMATIC_UPDATE);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, resultList, AUTOMATIC_UPDATE);
         assertEquals(0, resultList.size());
         assertEquals(0, realmAdapter.getData().size());
         assertEquals(0, realmAdapter.getItemCount());
@@ -140,7 +140,7 @@ public class RealmRecyclerAdapterTests {
     @UiThreadTest
     public void getItem_testGettingData() {
         RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).findAll();
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, resultList, AUTOMATIC_UPDATE);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, resultList, AUTOMATIC_UPDATE);
 
         assertEquals(resultList.first().getFieldString(), realmAdapter.getItem(0).getFieldString());
         assertEquals(resultList.size(), realmAdapter.getData().size());
@@ -150,7 +150,7 @@ public class RealmRecyclerAdapterTests {
     @Test
     @UiThreadTest
     public void getItem_testGettingNullData() {
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, null, AUTOMATIC_UPDATE);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, null, AUTOMATIC_UPDATE);
         assertNull(realmAdapter.getItem(0));
     }
 
@@ -158,7 +158,7 @@ public class RealmRecyclerAdapterTests {
     @UiThreadTest
     public void getItemId_testGetItemId() {
         RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).findAll();
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, resultList, AUTOMATIC_UPDATE);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, resultList, AUTOMATIC_UPDATE);
         for (int i = 0; i < resultList.size(); i++) {
             assertEquals(i, realmAdapter.getItemId(i));
         }
@@ -168,14 +168,14 @@ public class RealmRecyclerAdapterTests {
     @UiThreadTest
     public void getItemCount_testGetCount() {
         RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).findAll();
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, resultList, AUTOMATIC_UPDATE);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, resultList, AUTOMATIC_UPDATE);
         assertEquals(TEST_DATA_SIZE, realmAdapter.getItemCount());
     }
 
     @Test
     @UiThreadTest
     public void getItemCount_testNullResults() {
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, null, AUTOMATIC_UPDATE);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, null, AUTOMATIC_UPDATE);
         assertEquals(0, realmAdapter.getItemCount());
     }
 
@@ -183,7 +183,7 @@ public class RealmRecyclerAdapterTests {
     @UiThreadTest
     public void getItemCount_testNotValidResults() {
         RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).findAll();
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, resultList, AUTOMATIC_UPDATE);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, resultList, AUTOMATIC_UPDATE);
 
         realm.close();
         assertEquals(0, realmAdapter.getItemCount());
@@ -193,7 +193,7 @@ public class RealmRecyclerAdapterTests {
     @UiThreadTest
     public void getItemCount_testNonNullToNullResults() {
         RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).findAll();
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, resultList, AUTOMATIC_UPDATE);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, resultList, AUTOMATIC_UPDATE);
         realmAdapter.updateData(null);
 
         assertEquals(0, realmAdapter.getItemCount());
@@ -203,7 +203,7 @@ public class RealmRecyclerAdapterTests {
     @UiThreadTest
     public void getItemCount_testNullToNonNullResults() {
         RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).findAll();
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, null, AUTOMATIC_UPDATE);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, null, AUTOMATIC_UPDATE);
         assertEquals(0, realmAdapter.getItemCount());
 
         realmAdapter.updateData(resultList);
@@ -214,9 +214,9 @@ public class RealmRecyclerAdapterTests {
     @UiThreadTest
     public void viewHolderTestForSimpleView() {
         RealmResults<AllJavaTypes> resultList = realm.where(AllJavaTypes.class).findAll();
-        RealmRecyclerAdapter realmAdapter = new RealmRecyclerAdapter(context, resultList, AUTOMATIC_UPDATE);
+        RecyclerViewTestAdapter realmAdapter = new RecyclerViewTestAdapter(context, resultList, AUTOMATIC_UPDATE);
 
-        RealmRecyclerAdapter.ViewHolder holder = realmAdapter.onCreateViewHolder(new FrameLayout(context), 0);
+        RecyclerViewTestAdapter.ViewHolder holder = realmAdapter.onCreateViewHolder(new FrameLayout(context), 0);
         assertNotNull(holder.textView);
 
         realmAdapter.onBindViewHolder(holder, 0);

--- a/adapters/src/androidTest/java/io/realm/RealmRecyclerViewAdapterTests.java
+++ b/adapters/src/androidTest/java/io/realm/RealmRecyclerViewAdapterTests.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
-public class RealmBaseAdapterTests {
+public class RealmRecyclerViewAdapterTests {
     @Rule
     public final UiThreadTestRule uiThreadTestRule = new UiThreadTestRule();
 

--- a/adapters/src/androidTest/java/io/realm/adapter/RecyclerViewTestAdapter.java
+++ b/adapters/src/androidTest/java/io/realm/adapter/RecyclerViewTestAdapter.java
@@ -22,11 +22,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import io.realm.RealmBaseRecyclerAdapter;
+import io.realm.RealmRecyclerViewAdapter;
 import io.realm.RealmResults;
 import io.realm.entity.AllJavaTypes;
 
-public class RealmRecyclerAdapter extends RealmBaseRecyclerAdapter<AllJavaTypes, RealmRecyclerAdapter.ViewHolder> {
+public class RecyclerViewTestAdapter extends RealmRecyclerViewAdapter<AllJavaTypes, RecyclerViewTestAdapter.ViewHolder> {
 
     public static class ViewHolder extends RecyclerView.ViewHolder {
         public TextView textView;
@@ -37,7 +37,7 @@ public class RealmRecyclerAdapter extends RealmBaseRecyclerAdapter<AllJavaTypes,
         }
     }
 
-    public RealmRecyclerAdapter(final Context context, final RealmResults<AllJavaTypes> realmResults, final boolean automaticUpdate) {
+    public RecyclerViewTestAdapter(final Context context, final RealmResults<AllJavaTypes> realmResults, final boolean automaticUpdate) {
         super(context, realmResults, automaticUpdate);
     }
 

--- a/adapters/src/main/java/io/realm/RealmRecyclerViewAdapter.java
+++ b/adapters/src/main/java/io/realm/RealmRecyclerViewAdapter.java
@@ -34,7 +34,7 @@ import android.view.LayoutInflater;
  * @param <T> type of {@link RealmObject} stored in the adapter.
  * @param <VH> type of RecyclerView.ViewHolder used in the adapter.
  */
-public abstract class RealmBaseRecyclerAdapter<T extends RealmObject, VH extends RecyclerView.ViewHolder> extends RecyclerView.Adapter<VH> {
+public abstract class RealmRecyclerViewAdapter<T extends RealmObject, VH extends RecyclerView.ViewHolder> extends RecyclerView.Adapter<VH> {
 
     protected final LayoutInflater inflater;
     protected final Context context;
@@ -42,7 +42,7 @@ public abstract class RealmBaseRecyclerAdapter<T extends RealmObject, VH extends
     private final RealmChangeListener<BaseRealm> listener;
     private OrderedRealmCollection<T> adapterData;
 
-    public RealmBaseRecyclerAdapter(Context context, OrderedRealmCollection<T> data, boolean autoUpdate) {
+    public RealmRecyclerViewAdapter(Context context, OrderedRealmCollection<T> data, boolean autoUpdate) {
         if (context == null) {
             throw new IllegalArgumentException("Context can not be null");
         }


### PR DESCRIPTION
This PR adds the recent enhancements + credits to the Changelog.

Also, it changes the name of the `RealmRecyclerBaseAdapter` to `RealmRecyclerViewAdapter`. I completely missed this during review, but I think it is more in line with the naming in Android/RealmBaseAdapter:

`RealmBaseAdapter` was named so, after http://developer.android.com/intl/ja/reference/android/widget/BaseAdapter.html

For RecyclerView no such class exists, only https://developer.android.com/intl/ja/reference/android/support/v7/widget/RecyclerView.Adapter.html

Which would make `RealmRecyclerViewAdapter` fit the pattern better.

@realm/java