### PR TITLE
Removed unneeded appcompat dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.0
+
+### Bug fixes
+
+* Removed `appcompat-v7` from the library dependencies list.
+
+
 ## 1.0.1
 
 ### Bug fixes

--- a/adapters/build.gradle
+++ b/adapters/build.gradle
@@ -25,7 +25,6 @@ configurations {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.3.0'
     compile 'com.android.support:recyclerview-v7:23.3.0'
 
     androidTestCompile 'com.android.support.test:runner:0.4.1'


### PR DESCRIPTION
I think it snuck in when recreating the project from scratch. It is not needed by any of the adapters.

@realm/java 