### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.3.0
+
+### Enhancements
+
+* Added Android Support Annotations for all public adapter methods.
+
+### Credits
+
+* Lars Grefer (@larsgrefer) for adding the support annotations.
+
+
 ## 1.2.2
 
 ### Bug fixes


### PR DESCRIPTION
I noticed the support annotations where accidentially merged to releases instead of master (not a big problem since next release is 1.3.0), so this changelog update goes to `releases` as well.

@realm/java 