### PR TITLE
improve javadoc generation

### DIFF
--- a/adapters/build.gradle
+++ b/adapters/build.gradle
@@ -20,20 +20,12 @@ android {
     }
 }
 
-configurations {
-    javadoc
-}
-
 dependencies {
     compile 'com.android.support:recyclerview-v7:23.3.0'
 
     androidTestCompile 'com.android.support.test:runner:0.4.1'
     androidTestCompile 'com.android.support.test:rules:0.4.1'
     androidTestCompile 'junit:junit:4.12'
-
-    // TODO Hacking it for now. Try to make this work only from the javadoc task
-    javadoc "io.realm:realm-android-library:${rootProject.realmVersion}"
-    javadoc "io.realm:realm-annotations:${rootProject.realmVersion}"
 }
 
 task findbugs(type: FindBugs) {
@@ -92,7 +84,6 @@ task checkstyle(type: Checkstyle) {
 
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    classpath += configurations.javadoc
 
     options {
         title = "Realm Android Adapters ${project.version}"
@@ -101,6 +92,10 @@ task javadoc(type: Javadoc) {
         encoding = 'UTF-8'
         charSet = 'UTF-8'
         locale = 'en_US'
+
+        links "http://docs.oracle.com/javase/7/docs/api/"
+        links "https://realm.io/docs/java/${rootProject.realmVersion}/api/"
+        linksOffline "http://developer.android.com/reference/", "${project.android.sdkDirectory}/docs/reference"
     }
     exclude '**/BuildConfig.java'
     exclude '**/R.java'


### PR DESCRIPTION
Link against `Java SE 7` and `realm-java`

(and also against android itself, but this will only work in the `NO FRAMES` view)