### PR TITLE
Fixed crash of RealmRecyclerViewAdapter#updateData() when the adapterData in it was already invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.1
+
+### Bug fixes
+
+* Fixed crash of `RealmRecyclerViewAdapter#updateData()` when the `adapterData` in it was already invalid (#58).
+
+
 ## 1.4.0
 
 ### Enhancements

--- a/adapters/src/main/java/io/realm/RealmRecyclerViewAdapter.java
+++ b/adapters/src/main/java/io/realm/RealmRecyclerViewAdapter.java
@@ -137,7 +137,8 @@ public abstract class RealmRecyclerViewAdapter<T extends RealmModel, VH extends 
     @SuppressWarnings("WeakerAccess")
     public void updateData(@Nullable OrderedRealmCollection<T> data) {
         if (hasAutoUpdates) {
-            if (adapterData != null) {
+            if (isDataValid()) {
+                //noinspection ConstantConditions
                 removeListener(adapterData);
             }
             if (data != null) {


### PR DESCRIPTION
fixes #58 

Add a check if the `adapterData` in `RealmRecyclerViewAdapter` is still valid when `updateData()` is called.

@realm/java 