### PR TITLE
rename RealmRecyclerViewAdapterTests to RealmBaseAdapterTests

### DIFF
--- a/tests/src/androidTest/java/io/realm/RealmBaseAdapterTests.java
+++ b/tests/src/androidTest/java/io/realm/RealmBaseAdapterTests.java
@@ -35,11 +35,10 @@ import io.realm.entity.AllJavaTypes;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
-public class RealmRecyclerViewAdapterTests {
+public class RealmBaseAdapterTests {
     @Rule
     public final UiThreadTestRule uiThreadTestRule = new UiThreadTestRule();
 


### PR DESCRIPTION
Just renamed a name of a test class.

@realm/java 
