### PR TITLE
remove context with external transmit

### DIFF
--- a/adapters/src/main/java/io/realm/RealmRecyclerViewAdapter.java
+++ b/adapters/src/main/java/io/realm/RealmRecyclerViewAdapter.java
@@ -20,7 +20,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
-import android.view.LayoutInflater;
+import android.view.ViewGroup;
 
 /**
  * The RealmBaseRecyclerAdapter class is an abstract utility class for binding RecyclerView UI elements to Realm data.
@@ -39,41 +39,19 @@ import android.view.LayoutInflater;
 public abstract class RealmRecyclerViewAdapter<T extends RealmModel, VH extends RecyclerView.ViewHolder> extends RecyclerView.Adapter<VH> {
 
     @Nullable
-    @Deprecated
-    protected LayoutInflater inflater;
-    @Nullable
-    @Deprecated
     protected Context context;
     private final boolean hasAutoUpdates;
     private final RealmChangeListener listener;
     @Nullable
     private OrderedRealmCollection<T> adapterData;
 
-    @Deprecated
-    public RealmRecyclerViewAdapter(@NonNull Context context, @Nullable OrderedRealmCollection<T> data, boolean autoUpdate) {
-        if (data != null && !data.isManaged())
-            throw new IllegalStateException("Only use this adapter with managed list, " +
-                    "for un-managed lists you can just use the BaseAdapter");
-        //noinspection ConstantConditions
-        if (context == null) {
-            throw new IllegalArgumentException("Context can not be null");
-        }
-
-        this.context = context;
-        this.adapterData = data;
-        this.inflater = LayoutInflater.from(context);
-        this.hasAutoUpdates = autoUpdate;
-
-        // Right now don't use generics, since we need maintain two different
-        // types of listeners until RealmList is properly supported.
-        // See https://github.com/realm/realm-java/issues/989
-        this.listener = hasAutoUpdates ? new RealmChangeListener() {
-            @Override
-            public void onChange(Object results) {
-                notifyDataSetChanged();
-            }
-        } : null;
+    @Override
+    public VH onCreateViewHolder(ViewGroup parent, int viewType) {
+        context = parent.getContext();
+        return getViewHolder(parent,viewType);
     }
+
+    public abstract VH getViewHolder(ViewGroup parent, int viewType);
 
     public RealmRecyclerViewAdapter(@Nullable OrderedRealmCollection<T> data, boolean autoUpdate) {
         if (data != null && !data.isManaged())

--- a/example/src/main/java/io/realm/examples/adapters/ui/recyclerview/MyRecyclerViewAdapter.java
+++ b/example/src/main/java/io/realm/examples/adapters/ui/recyclerview/MyRecyclerViewAdapter.java
@@ -36,18 +36,19 @@ public class MyRecyclerViewAdapter extends RealmRecyclerViewAdapter<TimeStamp, M
         this.activity = activity;
     }
 
-    @Override
-    public MyViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        View itemView = LayoutInflater.from(parent.getContext())
-                .inflate(R.layout.row, parent, false);
-        return new MyViewHolder(itemView);
-    }
 
     @Override
     public void onBindViewHolder(MyViewHolder holder, int position) {
         TimeStamp obj = getData().get(position);
         holder.data = obj;
         holder.title.setText(obj.getTimeStamp());
+    }
+
+    @Override
+    public MyViewHolder getViewHolder(ViewGroup parent, int viewType) {
+        View itemView = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.row, parent, false);
+        return new MyViewHolder(itemView);
     }
 
     class MyViewHolder extends RecyclerView.ViewHolder implements View.OnLongClickListener {

--- a/tests/src/androidTest/java/io/realm/adapter/RecyclerViewTestAdapter.java
+++ b/tests/src/androidTest/java/io/realm/adapter/RecyclerViewTestAdapter.java
@@ -39,12 +39,13 @@ public class RecyclerViewTestAdapter extends RealmRecyclerViewAdapter<AllJavaTyp
 
     // TODO: Remove context dependency.
     public RecyclerViewTestAdapter(final Context context, final OrderedRealmCollection<AllJavaTypes> realmResults, final boolean automaticUpdate) {
-        super(context, realmResults, automaticUpdate);
+        super(realmResults, automaticUpdate);
     }
 
+
     @Override
-    public ViewHolder onCreateViewHolder(final ViewGroup parent, final int viewType) {
-        View view = inflater.inflate(android.R.layout.simple_list_item_1, parent, false);
+    public ViewHolder getViewHolder(ViewGroup parent, int viewType) {
+        View view = View.inflate(parent.getContext(),android.R.layout.simple_list_item_1, null);
         return new ViewHolder(view);
     }
 


### PR DESCRIPTION
We don't need transmit 'Context' from external . Also we can use 

```java
     @Override
    public VH onCreateViewHolder(ViewGroup parent, int viewType) {
        context = parent.getContext();
        return getViewHolder(parent,viewType);
    }
```
So, we can use ` context = parent.getContext();` that get context
