### PR TITLE
Detaching adapter when view gets destroyed to prevent leaking adapter which observes a managed collection

### DIFF
--- a/example/src/main/java/io/realm/examples/adapters/ui/recyclerview/RecyclerViewExampleActivity.java
+++ b/example/src/main/java/io/realm/examples/adapters/ui/recyclerview/RecyclerViewExampleActivity.java
@@ -48,6 +48,7 @@ public class RecyclerViewExampleActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        recycleView.setAdapter(null);
         realm.close();
     }
 


### PR DESCRIPTION
As javadoc suggests, Realm instance will be closed only if it is not referenced anywhere (https://github.com/realm/realm-java/blob/master/realm/realm-library/src/main/java/io/realm/RealmCache.java#L182). So, we need to detach Adapter from RecyclerView: when view gets destroyed, adapter never gets detached automatically from RecyclerView, which created a potential of memory leak.