### PR TITLE
Now RealmBaseAdapter behaves as empty if the adapterData is not valid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.1 (YYYY-MM-DD)
+
+### Bug fixes
+
+* Now `RealmBaseAdapter` behaves as empty if the `adapterData` is not valid (#112).
+
 ## 2.0.0 (2017-02-28)
 
 Works with Realm Java 3.x.

--- a/adapters/src/main/java/io/realm/RealmBaseAdapter.java
+++ b/adapters/src/main/java/io/realm/RealmBaseAdapter.java
@@ -47,7 +47,8 @@ public abstract class RealmBaseAdapter<T extends RealmModel> extends BaseAdapter
             }
         };
 
-        if (data != null) {
+        if (isDataValid()) {
+            //noinspection ConstantConditions
             addListener(data);
         }
     }
@@ -87,10 +88,8 @@ public abstract class RealmBaseAdapter<T extends RealmModel> extends BaseAdapter
      */
     @Override
     public int getCount() {
-        if (adapterData == null) {
-            return 0;
-        }
-        return adapterData.size();
+        //noinspection ConstantConditions
+        return isDataValid() ? adapterData.size() : 0;
     }
 
     /**
@@ -103,10 +102,8 @@ public abstract class RealmBaseAdapter<T extends RealmModel> extends BaseAdapter
     @Override
     @Nullable
     public T getItem(int position) {
-        if (adapterData == null) {
-            return null;
-        }
-        return adapterData.get(position);
+        //noinspection ConstantConditions
+        return isDataValid() ? adapterData.get(position) : null;
     }
 
     /**
@@ -137,15 +134,20 @@ public abstract class RealmBaseAdapter<T extends RealmModel> extends BaseAdapter
     @SuppressWarnings("WeakerAccess")
     public void updateData(@Nullable OrderedRealmCollection<T> data) {
         if (listener != null) {
-            if (adapterData != null) {
+            if (isDataValid()) {
+                //noinspection ConstantConditions
                 removeListener(adapterData);
             }
-            if (data != null) {
+            if (data != null && data.isValid()) {
                 addListener(data);
             }
         }
 
         this.adapterData = data;
         notifyDataSetChanged();
+    }
+
+    private boolean isDataValid() {
+        return adapterData != null && adapterData.isValid();
     }
 }

--- a/tests/src/androidTest/java/io/realm/RealmBaseAdapterTests.java
+++ b/tests/src/androidTest/java/io/realm/RealmBaseAdapterTests.java
@@ -35,6 +35,8 @@ import io.realm.entity.AllJavaTypes;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
@@ -231,4 +233,17 @@ public class RealmBaseAdapterTests {
         assertEquals(TEST_DATA_SIZE, realmAdapter.getCount());
     }
 
+    @Test
+    @UiThreadTest
+    public void adapterIsEmptyAfterClose() {
+        RealmResults<AllJavaTypes> result = realm.where(AllJavaTypes.class).findAll();
+        ListViewTestAdapter realmAdapter = new ListViewTestAdapter(context, result);
+
+        realm.close();
+        assertTrue(realm.isClosed());
+        realm = null;
+
+        assertEquals(0, realmAdapter.getCount());
+        assertNull(realmAdapter.getItem(0));
+    }
 }


### PR DESCRIPTION
fixes #112 

@realm/java 