### PR TITLE
Handle exception while adding extra position in adapter

### DIFF
--- a/adapters/src/main/java/io/realm/RealmRecyclerViewAdapter.java
+++ b/adapters/src/main/java/io/realm/RealmRecyclerViewAdapter.java
@@ -134,6 +134,7 @@ public abstract class RealmRecyclerViewAdapter<T extends RealmModel, S extends R
     /**
      * Returns the item associated with the specified position.
      * Can return {@code null} if provided Realm instance by {@link OrderedRealmCollection} is closed.
+     * Can return {@code null} if provided index is out of bound in adapterData (e.g: adding extra position in data to display footer view in recycler view)
      *
      * @param index index of the item.
      * @return the item at the specified position, {@code null} if adapter data is not valid.
@@ -141,6 +142,9 @@ public abstract class RealmRecyclerViewAdapter<T extends RealmModel, S extends R
     @SuppressWarnings("WeakerAccess")
     @Nullable
     public T getItem(int index) {
+        // To avoid exception, return null if there are some extra positions that the
+        // child adapter is adding in getItemCount (e.g: to display footer view in recycler view)
+        if(adapterData != null && index >= adapterData.size()) return null;
         //noinspection ConstantConditions
         return isDataValid() ? adapterData.get(index) : null;
     }


### PR DESCRIPTION
**Commit Message:** If user want to add an extra position from his adapter's getItemCount method to display Footer View in his RecyclerView then RealmRecyclerViewAdapter should not produce crash in its getItem() method.

-----------------------------------
**Goals:** RealmRecyclerViewAdapter should have provide reliable "Multiple-View-Type" support. For the time being, i am fixing a unnecessary crash that was restricting me to add an extra position in getItemCount() of my inherited Adapter class
**Expected results:** User can now safely add position from their Adapter's getItemCount method to display Footer View in their RecyclerView
Actual results: A crash is occurring and restricting us to add extra position from getItemCount method to display Footer View
Steps to reproduce: Follow any tutorial that shows how to add Footer View in RecyclerView (e.g: [this tutorial](http://www.gadgetsaint.com/android/recyclerview-header-footer-pagination/#.Wr5D09NuY_U) )
Code sample that highlights the issue (link to full Android Studio projects that we can compile ourselves are ideal): N/A
**Version of Realm/Android Studio/OS:** 
Realm: io.realm:realm-gradle-plugin:5.0.0
Android Studio 3.0.1
Build #AI-171.4443003, built on November 9, 2017
JRE: 1.8.0_152-release-915-b08 x86_64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
Mac OS X 10.13.3