### PR TITLE
Replace gradel 'compile' by 'api' in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.realm:android-adapters:2.1.1'
+    api 'io.realm:android-adapters:2.1.1'
 }
 ```
 
@@ -52,7 +52,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.realm:android-adapters:<version>'
+    api 'io.realm:android-adapters:<version>'
 }
 ```
 


### PR DESCRIPTION
'compile' is obsolete.